### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+
+      - run: pnpm test --run
+
+      - run: pnpm build


### PR DESCRIPTION
push / PR 時に lint・test・build を実行する CI を追加します。

- `jdx/mise-action` で node・pnpm のバージョンを自動セットアップ
- `pnpm lint`
- `pnpm test --run`
- `pnpm build`